### PR TITLE
Fix minor bugs

### DIFF
--- a/app.js
+++ b/app.js
@@ -77,7 +77,6 @@ function arrayChunks(items, num) {
 }
 
 let lastDay = 0, peerDomains = [], inactiveFeedChunks = [], watchedRosters = [];
-const twoWeeksAgo = dayjs().subtract(2, 'week');
 
 everyMinute(async (expectedCycleTime) => {
   let domain, homepage, feed, roster;
@@ -93,7 +92,7 @@ everyMinute(async (expectedCycleTime) => {
     peerDomains = await fedwikiHelper.fetchAllPeerDomains();
   }
 
-  domain = peerDomains.shift().toLowerCase();
+  domain = peerDomains.length > 0 ? peerDomains.shift().toLowerCase() : null;
   if (null != domain) {
     await feedHelper.fetchPeersOpml(domain, Cacheism.Status.cacheOnFail);
   }
@@ -104,6 +103,7 @@ everyMinute(async (expectedCycleTime) => {
   }
 
   if (0 === watchedRosters.length) {
+    const twoWeeksAgo = dayjs().subtract(2, 'week');
     watchedRosters = Object.values((await fedwikiHelper.fetchAllRosters()).data).filter((roster) => {
       return dayjs(roster.lastRequest).isAfter(twoWeeksAgo, 'day');
     });
@@ -113,7 +113,7 @@ everyMinute(async (expectedCycleTime) => {
     await feedHelper.fetchRosterOpml(roster.domain, roster.page, Cacheism.Status.cacheOnFail);
   }
 
-  allFeeds = Object.values((await fedwikiHelper.fetchAllFeeds()).data)
+  const allFeeds = Object.values((await fedwikiHelper.fetchAllFeeds()).data)
     .filter(filter => filter.active || false)
     .concat(inactiveFeedChunks.shift());
 

--- a/lib/fedwiki-helper.js
+++ b/lib/fedwiki-helper.js
@@ -143,8 +143,8 @@ async function fetchAllFeeds() {
   });
 
   if (0 === Object.keys(allFeedsCache.data).length) {
-    log.info(logPrefix, 'All Feeds Cache is empty!');
-    process.exit(0);
+    log.error(logPrefix, 'All Feeds Cache is empty!');
+    throw new Error('All Feeds Cache is empty');
   }
 
   for (const domain of Object.keys(allFeedsCache.data)) {
@@ -160,8 +160,8 @@ async function saveAllFeeds(data) {
   log.info(logPrefix, 'saveAllFeeds');
 
   if (0 === Object.keys(data).length) {
-    log.info(logPrefix, 'Wiping out all feeds cache!');
-    process.exit(0);
+    log.error(logPrefix, 'Refusing to save empty feeds cache!');
+    throw new Error('Refusing to save empty feeds cache');
   }
 
   await cache.go('-internal', 'allfeeds.json', Cacheism.Status.onlyFresh, _filterBlackList.bind(null, data));
@@ -218,7 +218,7 @@ async function fetchReferences(domain, page, cachePref) {
 
   const domains = new Set();
 
-  for (story of c.data.story) {
+  for (const story of c.data.story) {
     if (story.type === 'reference') {
       domains.add(story.site);
     }
@@ -253,10 +253,10 @@ async function fetchRoster(domain, page, cachePref, skip) {
 
   const domains = new Set();
 
-  for (story of c.data.story) {
+  for (const story of c.data.story) {
     if (story.type === 'roster') {
 
-      let lines = story.text.split(new RegExp('\r?\n')), parts, roster;
+      let lines = story.text.split(new RegExp('\r?\n')), rosterParts, subRoster;
       for (let line of lines) {
         let match = line.match(new RegExp('^([a-zA-Z0-9-]+(\\.[a-zA-Z0-9-]+)+)(:\d+)?$'));
         if (null == match) {
@@ -274,11 +274,11 @@ async function fetchRoster(domain, page, cachePref, skip) {
             continue;
           }
           skip[match[1]] = true;
-          parts = match[1].split('/', 2);
-          if (2 === parts.length) {
-            roster = await fetchRoster(parts[0], parts[1], cachePref, skip)
-            if (roster.isHit && Array.isArray(roster.data?.domains)) {
-              roster.data.domains.forEach((d) => {
+          rosterParts = match[1].split('/', 2);
+          if (2 === rosterParts.length) {
+            subRoster = await fetchRoster(rosterParts[0], rosterParts[1], cachePref, skip)
+            if (subRoster.isHit && Array.isArray(subRoster.data?.domains)) {
+              subRoster.data.domains.forEach((d) => {
                 domains.add(d);
               });
             }
@@ -289,9 +289,9 @@ async function fetchRoster(domain, page, cachePref, skip) {
           match = line.match(new RegExp('^REFERENCES ([A-Za-z0-9.-:]+\/[a-z0-9-]+)$'));
         }
         if (null != match) {
-          parts = match[1].split('/', 2);
-          if (2 === parts.length) {
-            references = await fetchReferences(parts[0], parts[1], cachePref)
+          const refParts = match[1].split('/', 2);
+          if (2 === refParts.length) {
+            const references = await fetchReferences(refParts[0], refParts[1], cachePref)
             if (references.isHit && Array.isArray(references.data)) {
               references.data.forEach((d) => {
                 domains.add(d);

--- a/lib/get-if-new.js
+++ b/lib/get-if-new.js
@@ -49,6 +49,7 @@ function factory(cache) {
 
   async function getJsonIfNew(scheme, domain, path, cachePref) {
     return cache.go(domain, `${scheme}-${path}`, cachePref || Cacheism.Status.cacheOnFail, async (existing) => {
+      let response;
       try {
         response = await getResponse(scheme, domain, path, existing.etag);
       } catch (err) {
@@ -61,7 +62,7 @@ function factory(cache) {
       }
 
       if (200 === response.status) {
-        etag = response.headers.get('ETag');
+        const etag = response.headers.get('ETag');
         return new Cacheism.Hit(existing.cacheName, await response.json(), etag);
       } else if (-1 === [304, 404].indexOf(response.status)) {
         log.error(logPrefix, '%s: %s://%s/%s', response.status, scheme, domain, path);
@@ -72,6 +73,7 @@ function factory(cache) {
 
   async function getTextIfNew(scheme, domain, path, cachePref) {
     return cache.go(domain, `${scheme}-${path}`, cachePref || Cacheism.Status.cacheOnFail, async (existing) => {
+      let response;
       try {
         response = await getResponse(scheme, domain, path, existing.etag);
       } catch (err) {
@@ -79,13 +81,12 @@ function factory(cache) {
         if (cachePref === Cacheism.Status.onlyFresh) {
           return new Cacheism.Miss(existing.cacheName, err);
         } else {
-          throw new Error('test');
           return existing;
         }
       }
 
       if (200 === response.status) {
-        etag = response.headers.get('ETag');
+        const etag = response.headers.get('ETag');
         return new Cacheism.Hit(existing.cacheName, await response.text(), etag);
       } else if (-1 === [304, 404].indexOf(response.status)) {
         log.error(logPrefix, '%s: %s://%s/%s', response.status, scheme, domain, path);

--- a/routes/index.js
+++ b/routes/index.js
@@ -6,8 +6,24 @@ const feedHelper = require('../lib/feed-helper');
 const csv = require('csv/sync');
 const dayjs = require('../lib/day.js');
 
+const log = require('../lib/log');
+const logPrefix = 'routes/index ';
+
 const Cacheism = require('@andrewshell/cacheism');
 const cache = new Cacheism(Cacheism.store.filesystem(config));
+
+const SAFE_CALLBACK_RE = /^[a-zA-Z_$][\w$.]*$/;
+
+function asyncHandler(fn) {
+  return function (req, res, next) {
+    Promise.resolve(fn(req, res, next)).catch(next);
+  };
+}
+
+function safeCallback(req) {
+  const cb = req.query.callback || 'onGetRiverStream';
+  return SAFE_CALLBACK_RE.test(cb) ? cb : 'onGetRiverStream';
+}
 
 function sendCachedOutput(req, res, cacheRes, contentType) {
   const ifNoneMatch = req.get('if-none-match');
@@ -20,7 +36,7 @@ function sendCachedOutput(req, res, cacheRes, contentType) {
   } else if (ifModifiedSince && cacheRes.created <= (new Date(ifModifiedSince))) {
     res.status(304).send();
   } else {
-    console.log(`etag: ${cacheRes.etag}`);
+    log.info(logPrefix, 'etag: %s', cacheRes.etag);
     res.header("Content-Type", contentType);
     res.header("ETag", cacheRes.etag);
     res.status(200).send(cacheRes.data);
@@ -42,7 +58,7 @@ router.get('/', function(req, res, next) {
  * All Feeds
  */
 
-router.get('/river.html', async function (req, res, next) {
+router.get('/river.html', asyncHandler(async function (req, res, next) {
   res.render('river', {
     layout: false,
     domain: req.headers.host || 'fedwikiriver.com',
@@ -51,14 +67,14 @@ router.get('/river.html', async function (req, res, next) {
     opmlList: `/river.opml`,
     jsonFeed: `/river.js`
   });
-});
+}));
 
-router.get('/river.opml', async function (req, res, next) {
+router.get('/river.opml', asyncHandler(async function (req, res, next) {
   const output = await feedHelper.fetchAllFeeds();
   sendCachedOutput(req, res, output, 'text/xml');
-});
+}));
 
-router.get('/river.csv', async function (req, res, next) {
+router.get('/river.csv', asyncHandler(async function (req, res, next) {
   const allfeeds = await fedwikiHelper.fetchAllFeeds();
   const domains = Object.values(allfeeds.data)
       .filter(filter => true === filter.active )
@@ -71,10 +87,10 @@ router.get('/river.csv', async function (req, res, next) {
     return items;
   }, []);
   sendCachedOutput(req, res, cache.hit(output.cacheName, csv.stringify(flattened)), 'text/csv');
-});
+}));
 
-router.get('/river.js', async function (req, res, next) {
-  const callback = req.query.callback || 'onGetRiverStream';
+router.get('/river.js', asyncHandler(async function (req, res, next) {
+  const callback = safeCallback(req);
   const allfeeds = await fedwikiHelper.fetchAllFeeds();
   const domains = Object.values(allfeeds.data)
       .filter(filter => true === filter.active )
@@ -82,36 +98,36 @@ router.get('/river.js', async function (req, res, next) {
   const output = await feedHelper.fetchRiver('Federated Wiki River', domains);
   const json = JSON.stringify(output.data, null, 2);
   sendCachedOutput(req, res, cache.hit(output.cacheName, `${callback}(${json});`), 'application/javascript');
-});
+}));
 
-router.get('/river.json', async function (req, res, next) {
+router.get('/river.json', asyncHandler(async function (req, res, next) {
   const allfeeds = await fedwikiHelper.fetchAllFeeds();
   const domains = Object.values(allfeeds.data)
       .filter(filter => true === filter.active )
       .map(feed => feed.text);
   const output = await feedHelper.fetchRiver('Federated Wiki River', domains);
   sendCachedOutput(req, res, output, 'application/json');
-});
+}));
 
-router.get('/activefeeds.opml', async function (req, res, next) {
+router.get('/activefeeds.opml', asyncHandler(async function (req, res, next) {
   const output = await feedHelper.fetchActiveFeeds();
   sendCachedOutput(req, res, output, 'text/xml');
-});
+}));
 
 /**
  * Domains
  */
 
-router.get('/:domain/rss.xml', async function(req, res, next) {
+router.get('/:domain/rss.xml', asyncHandler(async function(req, res, next) {
   const output = await feedHelper.fetchSiteRss(req.params.domain, Cacheism.Status.preferCache);
   sendCachedOutput(req, res, output, 'application/rss+xml');
-});
+}));
 
 /**
  * Peers
  */
 
-router.get('/:domain/peers.html', async function (req, res, next) {
+router.get('/:domain/peers.html', asyncHandler(async function (req, res, next) {
   res.render('river', {
     layout: false,
     domain: req.headers.host || req.params.domain,
@@ -120,28 +136,28 @@ router.get('/:domain/peers.html', async function (req, res, next) {
     opmlList: `/${req.params.domain}/peers.opml`,
     jsonFeed: `/${req.params.domain}/peers.js`
   });
-});
+}));
 
-router.get('/:domain/peers.opml', async function (req, res, next) {
+router.get('/:domain/peers.opml', asyncHandler(async function (req, res, next) {
   const output = await feedHelper.fetchPeersOpml(req.params.domain, Cacheism.Status.preferCache);
   sendCachedOutput(req, res, output, 'text/xml');
-});
+}));
 
-router.get('/:domain/peers.js', async function (req, res, next) {
-  const callback = req.query.callback || 'onGetRiverStream';
+router.get('/:domain/peers.js', asyncHandler(async function (req, res, next) {
+  const callback = safeCallback(req);
   const peers = await fedwikiHelper.fetchPeers(req.params.domain, Cacheism.Status.preferCache);
   const output = await feedHelper.fetchRiver(`Peers of ${req.params.domain}`, peers.data);
   const json = JSON.stringify(output.data, null, 2);
   sendCachedOutput(req, res, cache.hit(output.cacheName, `${callback}(${json});`), 'application/javascript');
-});
+}));
 
-router.get('/:domain/peers.json', async function (req, res, next) {
+router.get('/:domain/peers.json', asyncHandler(async function (req, res, next) {
   const peers = await fedwikiHelper.fetchPeers(req.params.domain, Cacheism.Status.preferCache);
   const output = await feedHelper.fetchRiver(`Peers of ${req.params.domain}`, peers.data);
   sendCachedOutput(req, res, output, 'application/json');
-});
+}));
 
-router.get('/:domain/peers.csv', async function (req, res, next) {
+router.get('/:domain/peers.csv', asyncHandler(async function (req, res, next) {
   const peers = await fedwikiHelper.fetchPeers(req.params.domain, Cacheism.Status.preferCache);
   const output = await feedHelper.fetchRiver(`Peers of ${req.params.domain}`, peers.data);
   const flattened = output.data.updatedFeeds.updatedFeed.reduce((items, feed) => {
@@ -151,13 +167,13 @@ router.get('/:domain/peers.csv', async function (req, res, next) {
     return items;
   }, []);
   sendCachedOutput(req, res, cache.hit(output.cacheName, csv.stringify(flattened)), 'text/csv');
-});
+}));
 
 /**
  * Rosters
  */
 
-router.get('/:domain/:page/roster.html', async function (req, res, next) {
+router.get('/:domain/:page/roster.html', asyncHandler(async function (req, res, next) {
   const roster = await fedwikiHelper.fetchRoster(req.params.domain, req.params.page, Cacheism.Status.preferCache);
   res.render('river', {
     layout: false,
@@ -167,9 +183,9 @@ router.get('/:domain/:page/roster.html', async function (req, res, next) {
     opmlList: `/${req.params.domain}/${req.params.page}/roster.opml`,
     jsonFeed: `/${req.params.domain}/${req.params.page}/roster.js`
   });
-});
+}));
 
-router.get('/:domain/:page/roster.opml', async function (req, res, next) {
+router.get('/:domain/:page/roster.opml', asyncHandler(async function (req, res, next) {
   let allrosters = (await fedwikiHelper.fetchAllRosters()).data;
   allrosters[`${req.params.domain}/${req.params.page}`] = {
     domain: req.params.domain,
@@ -180,9 +196,9 @@ router.get('/:domain/:page/roster.opml', async function (req, res, next) {
 
   const output = await feedHelper.fetchRosterOpml(req.params.domain, req.params.page, Cacheism.Status.preferCache);
   sendCachedOutput(req, res, output, 'text/xml');
-});
+}));
 
-router.get('/:domain/:page/roster.js', async function (req, res, next) {
+router.get('/:domain/:page/roster.js', asyncHandler(async function (req, res, next) {
   let allrosters = (await fedwikiHelper.fetchAllRosters()).data;
   allrosters[`${req.params.domain}/${req.params.page}`] = {
     domain: req.params.domain,
@@ -191,14 +207,14 @@ router.get('/:domain/:page/roster.js', async function (req, res, next) {
   };
   await fedwikiHelper.saveAllRosters(allrosters);
 
-  const callback = req.query.callback || 'onGetRiverStream';
+  const callback = safeCallback(req);
   const roster = await fedwikiHelper.fetchRoster(req.params.domain, req.params.page, Cacheism.Status.preferCache);
   const output = await feedHelper.fetchRiver(`Roster from ${req.params.domain}/${req.params.page}`, roster.data.domains);
   const json = JSON.stringify(output.data, null, 2);
   sendCachedOutput(req, res, cache.hit(output.cacheName, `${callback}(${json});`), 'application/javascript');
-});
+}));
 
-router.get('/:domain/:page/roster.json', async function (req, res, next) {
+router.get('/:domain/:page/roster.json', asyncHandler(async function (req, res, next) {
   let allrosters = (await fedwikiHelper.fetchAllRosters()).data;
   allrosters[`${req.params.domain}/${req.params.page}`] = {
     domain: req.params.domain,
@@ -210,9 +226,9 @@ router.get('/:domain/:page/roster.json', async function (req, res, next) {
   const roster = await fedwikiHelper.fetchRoster(req.params.domain, req.params.page, Cacheism.Status.preferCache);
   const output = await feedHelper.fetchRiver(`Roster from ${req.params.domain}/${req.params.page}`, roster.data.domains);
   sendCachedOutput(req, res, output, 'application/json');
-});
+}));
 
-router.get('/:domain/:page/roster.csv', async function (req, res, next) {
+router.get('/:domain/:page/roster.csv', asyncHandler(async function (req, res, next) {
   let allrosters = (await fedwikiHelper.fetchAllRosters()).data;
   allrosters[`${req.params.domain}/${req.params.page}`] = {
     domain: req.params.domain,
@@ -230,6 +246,6 @@ router.get('/:domain/:page/roster.csv', async function (req, res, next) {
     return items;
   }, []);
   sendCachedOutput(req, res, cache.hit(output.cacheName, csv.stringify(flattened)), 'text/csv');
-});
+}));
 
 module.exports = router;


### PR DESCRIPTION
- Remove leftover `throw new Error('test')` in getTextIfNew that broke cache fallback
- Add let/const declarations for response, etag, story, references, parts to prevent implicit global variable pollution
- Replace process.exit(0) with thrown errors on empty feeds cache
- Move twoWeeksAgo computation inside everyMinute to prevent stale date
- Guard peerDomains.shift() against empty array crash
- Wrap all async route handlers with asyncHandler for proper error propagation
- Sanitize JSONP callback parameter to prevent injection
- Replace console.log with log.info in routes